### PR TITLE
Docs: Auto update gh-pages with updated Javadocs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,22 +47,72 @@ jobs:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build:
-    needs: lint
+    name: Build Project & Generate Javadoc
     runs-on: ubuntu-latest
+    needs: lint
 
     steps:
+      - name: Checkout code
       - uses: actions/checkout@v6
+      
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
+          
       - name: Build with Maven
         run: mvn -B package --file HelloWorldCode/HelloWorldCode/pom.xml
+      
+      - name: Generate Javadoc
+        run: mvn javadoc:javadoc --file HelloWorldCode/HelloWorldCode/pom.xml
 
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-      - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8
+      - name: Upload Javadoc
+        uses: actions/upload-artifact@v6
         with:
-          directory: HelloWorldCode/HelloWorldCode
+          name: javadoc
+          path: HelloWorldCode/HelloWorldCode/target/reports/apidocs
+
+  deploy-javadoc: 
+    name: Deploy Javadocs to gh-pages
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+     - name: Checkout gh-pages
+       uses: actions/checkout@v6
+       with:
+         ref: gh-pages
+         fetch-depth: 0
+
+     - name: Download Javadocs
+       uses: actions/download-artifact@v6
+       with:
+         name: javadoc
+         path: new-apidocs
+
+     - name: Sync Javadoc changes into /main
+       run: | 
+         mkdir -p main
+
+         rsync -av --delete new-apidocs/ main/
+     
+     - name: Commit & push if changes exist
+       run: |
+         git config user.name "github-actions[bot]"
+         git config user.email "github-actions[bot]@users/noreply/github.com"
+         git add .
+         git diff-index --quiet HEAD || git commit -m "Update Javadocs from workflow"
+         git push origin gh-pages
+
+# Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+     - name: Update dependency graph
+       uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8
+       with: 
+         directory: HelloWorldCode/HelloWorldCode
+
+      
+
+    
+


### PR DESCRIPTION
Updated Javadocs will be deployed to gh-pages after building the project.
Closes #43 